### PR TITLE
using Join for aerospike_cluster script

### DIFF
--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -359,35 +359,60 @@ Resources:
               owner: root
               group: root
             /opt/aerospike/cft_scripts/aerospike_cluster:
-              content: !Sub
-                - |
-                  #!/bin/bash
-                  echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
-                  PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
-                  CONF=/etc/aerospike/aerospike.conf
-                  sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
-                  ###Point to all instances using the mesh-address config option
-                  sleep 60 # wait for AWS to provision
-                  FILTER=Name=tag-key,Values=StackID
-                  PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values='${AWS::StackId} --output=text --region=${REGION} | grep PRIVATEIPADDRESSES | awk '{print $4}')
-                  echo $PRIVATEIP >> /var/log/awsuserdatascript
-                  sed -i '/.*mesh-seed-address-port/d' $CONF
-                  for i in $PRIVATEIP; do
-                    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
-                  done
-                  CODE=$(curl -Is ${NamespaceFile} | head -n 1 | cut -d$' ' -f2)
-                  if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
-                  else sed -i '/namespace test/,$d' $CONF
-                  curl -s ${NamespaceFile} >> $CONF; fi
-                  systemctl restart aerospike
-
-                  echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
-                  (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
-
-                  if [[ "${EnableCloudWatch}" == "yes" ]]; then
-                    (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -
-                  fi
-                - REGION: !Sub "${AWS::Region}"
+              content: !Join 
+                - ''
+                - - |
+                    #!/bin/bash
+                  - >
+                    echo ClusterInstancesScriptStart >
+                    /var/log/awsuserdatascript
+                  - |2
+                      PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+                  - |2
+                      CONF=/etc/aerospike/aerospike.conf
+                  - "  sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
+                  - |2
+                      ###Point to all instances using the mesh-address config option
+                  - |2
+                      sleep 60 # wait for AWS to provision 
+                  - '  PRIVATEIP=$(aws ec2 describe-instances --filter Name=tag-key,Values=StackID Name=tag-value,Values='
+                  - !Ref 'AWS::StackId'
+                  - ' --output=text --region='
+                  - !Ref 'AWS::Region'
+                  - |2
+                     | grep PRIVATEIPADDRESSES | awk '{print $4}') 
+                  - |2
+                      echo $PRIVATEIP >> /var/log/awsuserdatascript
+                  - |2
+                      sed -i '/.*mesh-seed-address-port/d' $CONF
+                  - '  for i in $PRIVATEIP; do '
+                  - "    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF; done\n"
+                  - '  CODE=$(curl -Is '
+                  - !Ref NamespaceFile
+                  - |2
+                     | head -n 1 | cut -d$' ' -f2)
+                  - |2
+                      if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
+                  - |2
+                      else sed -i '/namespace test/,$d' $CONF
+                  - '    curl -s '
+                  - !Ref NamespaceFile
+                  - |2
+                     >> $CONF; fi
+                  - |2
+                      systemctl restart aerospike
+                  - >
+                    echo OtherInstancesScriptFinish >>
+                    /var/log/awsuserdatascript
+                  - >
+                    (crontab -l 2>/dev/null; echo '*/5 * * * *
+                    /opt/aerospike/poll_sqs') | crontab -
+                  - '  if [[ "'
+                  - !Ref Cloudwatch
+                  - |
+                    " == "yes" ]]; then
+                  - |2
+                        (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -; fi
               mode: '000744'
               owner: root
               group: root

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -408,7 +408,7 @@ Resources:
                     (crontab -l 2>/dev/null; echo '*/5 * * * *
                     /opt/aerospike/poll_sqs') | crontab -
                   - '  if [[ "'
-                  - !Ref Cloudwatch
+                  - !Ref EnableCloudWatch
                   - |
                     " == "yes" ]]; then
                   - |2


### PR DESCRIPTION
It was found that the command ` sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"` 
in **Sub** function takes `\t` as literal text and doesn't replace it with tab, whereas in **Join** function it replaces it with whitespaces which is needed to `aerospike_cluster` script to work properly. 

Correct command which should be present in the aerospike_cluster  file :  
``` bash
 sed -i "/port 3000/a \    access-address $PRIVATE_IP virtual" $CONF
 ```
 
 **Config file before**
 ```bash
 #!/bin/bash
  echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
  PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
  CONF=/etc/aerospike/aerospike.conf
  sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
  ###Point to all instances using the mesh-address config option
  sleep 60 # wait for AWS to provision
  FILTER=Name=tag-key,Values=StackID
  PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values='${AWS::StackId} --output=text --region=${REGION} | grep PRIVATEIPADDRESSES | awk '{print $4}')
  echo $PRIVATEIP >> /var/log/awsuserdatascript
  sed -i '/.*mesh-seed-address-port/d' $CONF
  for i in $PRIVATEIP; do
    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
  done
  CODE=$(curl -Is ${NamespaceFile} | head -n 1 | cut -d$' ' -f2)
  if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
  else sed -i '/namespace test/,$d' $CONF
  curl -s ${NamespaceFile} >> $CONF; fi
  systemctl restart aerospike
  echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
  (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
  if [[ "${EnableCloudWatch}" == "yes" ]]; then
    (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -
  fi
 ```
**Config file after**
``` bash
[ec2-user@ip-10-0-8-44 ~]$ cat /opt/aerospike/cft_scripts/aerospike_cluster
#!/bin/bash
echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
  PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
  CONF=/etc/aerospike/aerospike.conf
  sed -i "/port 3000/a \		access-address $PRIVATE_IP virtual" $CONF
  ###Point to all instances using the mesh-address config option
  sleep 60 # wait for AWS to provision
  PRIVATEIP=$(aws ec2 describe-instances --filter Name=tag-key,Values=StackID Name=tag-value,Values=arn:aws:cloudformation:us-east-1:040921035827:stack/test3-AerospikeServerStack-7XDNH7LF6UPR/6d72e7a0-ca30-11eb-aba4-0ac49251e793 --output=text --region=us-east-1 | grep PRIVATEIPADDRESSES | awk '{print $4}')
  echo $PRIVATEIP >> /var/log/awsuserdatascript
  sed -i '/.*mesh-seed-address-port/d' $CONF
  for i in $PRIVATEIP; do     sed -i "/interval/i \		mesh-seed-address-port $i 3002" $CONF; done
  CODE=$(curl -Is  | head -n 1 | cut -d$' ' -f2)
  if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
  else sed -i '/namespace test/,$d' $CONF
    curl -s  >> $CONF; fi
  systemctl restart aerospike
echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
(crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
  if [[ "no" == "yes" ]]; then
    (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -; fi
```

**Test with 2 node**

![Screen Shot 2021-06-10 at 2 16 57 PM](https://user-images.githubusercontent.com/7384893/121598368-9c848380-c9f6-11eb-99a3-99352efe7417.png)

![Screen Shot 2021-06-10 at 2 17 13 PM](https://user-images.githubusercontent.com/7384893/121598415-a7d7af00-c9f6-11eb-83fd-aae5a9aacba4.png)

![Screen Shot 2021-06-10 at 2 17 25 PM](https://user-images.githubusercontent.com/7384893/121598429-aa3a0900-c9f6-11eb-8f73-06f30c85febe.png)
