### PR TITLE
adding cluster formation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+
+.taskcat_overrides.yml
+.idea
+venv
+.venv
+.DS_Store
+.taskcat
+functions/packages
+output
+__pycache__
+docs/generated/
+index.html
+.python-version
+.idea
+taskcat_outputs
+venv

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -22,7 +22,7 @@ tests:
       AvailabilityZones: $[taskcat_genaz_2]
       NumberOfAZs: 2
     regions:
-    - eu-west-1
+    - us-east-1
   aerospike-multi-region:
     parameters:
       AvailabilityZones: $[taskcat_genaz_3]

--- a/scripts/aerospike_cluster.sh
+++ b/scripts/aerospike_cluster.sh
@@ -2,21 +2,24 @@
 echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
 PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 CONF=/etc/aerospike/aerospike.conf
-sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
+sed -i "s/port 3000/port 3000\n\t\taccess-address $PRIVATE_IP virtual\n/g" $CONF
+
 
 ###Point to all instances using the mesh-address config option
 sleep 60 # wait for AWS to provision
 FILTER=Name=tag-key,Values=StackID
-PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values='${AWS::StackId} --output=text --region=$1 | grep PRIVATEIPADDRESSES | awk '{print $4}')
+PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values=$3 --output=text --region=$1 | grep PRIVATEIPADDRESSES | awk '{print $4}')
 echo $PRIVATEIP >> /var/log/awsuserdatascript
 sed -i '/.*mesh-seed-address-port/d' $CONF
 for i in $PRIVATEIP; do
-    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
+    sed -i "/interval/i \\\t\tmesh-seed-address-port $i 3002\n" $CONF
 done
-CODE=$(curl -Is $3 | head -n 1 | cut -d$' ' -f2)
+
+# Check if namespace file in input
+CODE=$(curl -Is $4 | head -n 1 | cut -d$' ' -f2)
 if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
 else sed -i '/namespace test/,$d' $CONF
-curl -s $3 >> $CONF; fi
+curl -s $4 >> $CONF; fi
 systemctl restart aerospike
 
 echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript

--- a/scripts/aerospike_cluster.sh
+++ b/scripts/aerospike_cluster.sh
@@ -13,14 +13,14 @@ sed -i '/.*mesh-seed-address-port/d' $CONF
 for i in $PRIVATEIP; do
     sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
 done
-CODE=$(curl -Is $2 | head -n 1 | cut -d$' ' -f2)
+CODE=$(curl -Is $3 | head -n 1 | cut -d$' ' -f2)
 if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
 else sed -i '/namespace test/,$d' $CONF
-curl -s $2 >> $CONF; fi
+curl -s $3 >> $CONF; fi
 systemctl restart aerospike
 
 echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
 (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
-if [[ "$3" == "yes" ]]; then
+if [[ "$2" == "yes" ]]; then
 (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -
 fi

--- a/scripts/aerospike_cluster.sh
+++ b/scripts/aerospike_cluster.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
+PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+CONF=/etc/aerospike/aerospike.conf
+sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
+
+###Point to all instances using the mesh-address config option
+sleep 60 # wait for AWS to provision
+FILTER=Name=tag-key,Values=StackID
+PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values='${AWS::StackId} --output=text --region=$1 | grep PRIVATEIPADDRESSES | awk '{print $4}')
+echo $PRIVATEIP >> /var/log/awsuserdatascript
+sed -i '/.*mesh-seed-address-port/d' $CONF
+for i in $PRIVATEIP; do
+    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
+done
+CODE=$(curl -Is $2 | head -n 1 | cut -d$' ' -f2)
+if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
+else sed -i '/namespace test/,$d' $CONF
+curl -s $2 >> $CONF; fi
+systemctl restart aerospike
+
+echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
+(crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
+if [[ "$3" == "yes" ]]; then
+(crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -
+fi

--- a/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
+++ b/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
@@ -424,6 +424,8 @@ Resources:
         EBS: !Ref EBS
         NamespaceFile: !Ref NamespaceFile
         FeatureKeyFile: !Ref FeatureKeyFile
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
 
 Outputs:
   BastionHostIP:

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -393,7 +393,7 @@ Resources:
                   #!/bin/bash
                   aws s3 cp s3://${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh .
                   chmod +x aerospike_cluster.sh
-                  ./aerospike_cluster.sh ${REGION} ${EnableCloudWatch}  ${NamespaceFile}
+                  ./aerospike_cluster.sh ${REGION} ${EnableCloudWatch} ${AWS::StackId} ${NamespaceFile}
                 - REGION: !Sub "${AWS::Region}" 
                   S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               mode: '000744'
@@ -541,7 +541,7 @@ Resources:
               command: /opt/aerospike/cft_scripts/aerospike_init
               cwd: /opt/aerospike/cft_scripts
             01_form_asd_cluster:
-              command: /opt/aerospike/cft_scripts/aerospike_cluster
+              command:  /opt/aerospike/cft_scripts/aerospike_cluster
               cwd: /opt/aerospike/cft_scripts
             02_aerospike_start:
               command: /opt/aerospike/cft_scripts/aerospike_start

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -389,7 +389,7 @@ Resources:
               content: !Sub
                 - |
                   #!/bin/bash
-                  aws s3 cp https://s3.amazonaws.com/aerospike.cloud-templates.test/QSTemp/11jun/aerospike_cluster.sh .
+                  aws s3 cp s3://${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh .
                   chmod +x aerospike_cluster.sh
                   ./aerospike_cluster.sh ${REGION} ${NamespaceFile} ${EnableCloudWatch}
                 - REGION: !Sub "${AWS::Region}" 

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -393,7 +393,7 @@ Resources:
                   #!/bin/bash
                   aws s3 cp s3://${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh .
                   chmod +x aerospike_cluster.sh
-                  ./aerospike_cluster.sh ${REGION} ${NamespaceFile} ${EnableCloudWatch}
+                  ./aerospike_cluster.sh ${REGION} ${EnableCloudWatch}  ${NamespaceFile}
                 - REGION: !Sub "${AWS::Region}" 
                   S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               mode: '000744'

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -362,32 +362,11 @@ Resources:
               content: !Sub
                 - |
                   #!/bin/bash
-                  echo ClusterInstancesScriptStart > /var/log/awsuserdatascript
-                  PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
-                  CONF=/etc/aerospike/aerospike.conf
-                  sed -i \"/port 3000/a \\\t\taccess-address $PRIVATE_IP virtual\" $CONF\n"
-                  ###Point to all instances using the mesh-address config option
-                  sleep 60 # wait for AWS to provision
-                  FILTER=Name=tag-key,Values=StackID
-                  PRIVATEIP=$(aws ec2 describe-instances --filter $FILTER  Name=tag-value,Values='${AWS::StackId} --output=text --region=${REGION} | grep PRIVATEIPADDRESSES | awk '{print $4}')
-                  echo $PRIVATEIP >> /var/log/awsuserdatascript
-                  sed -i '/.*mesh-seed-address-port/d' $CONF
-                  for i in $PRIVATEIP; do
-                    sed -i \"/interval/i \\\t\tmesh-seed-address-port $i 3002\" $CONF
-                  done
-                  CODE=$(curl -Is ${NamespaceFile} | head -n 1 | cut -d$' ' -f2)
-                  if [ "$CODE" != "200" ]; then echo 'Namespace File not found' >> /var/log/awsuserdatascript
-                  else sed -i '/namespace test/,$d' $CONF
-                  curl -s ${NamespaceFile} >> $CONF; fi
-                  systemctl restart aerospike
-
-                  echo OtherInstancesScriptFinish >> /var/log/awsuserdatascript
-                  (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/poll_sqs') | crontab -
-
-                  if [[ "${EnableCloudWatch}" == "yes" ]]; then
-                    (crontab -l 2>/dev/null; echo '*/5 * * * * /opt/aerospike/cloudwatch') | crontab -
-                  fi
+                  aws s3 cp s3://${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh .
+                  chmod +x aerospike_cluster.sh
+                  ./aerospike_cluster.sh ${REGION} ${NamespaceFile} ${EnableCloudWatch}
                 - REGION: !Sub "${AWS::Region}"
+                - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               mode: '000744'
               owner: root
               group: root

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -226,11 +226,6 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       a forward slash (/).
     Type: String
-  NumberOfAZs:
-    Type: String
-    AllowedValues: ["2", "3"]
-    Default: "3"
-    Description: Number of Availability Zones to use in the VPC. This must match the value entered for the AvailabilityZones parameter.
 Mappings:
   AWSAMIRegionMap:
     AMI:
@@ -271,13 +266,10 @@ Mappings:
       AEROSPIKEAMI: ami-0e85ec1cd8e86df3b
 
 Conditions:
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   NotUsingEBS: !Equals 
     - !Ref EBS
     - 0
-
-Conditions:
-  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  3AZDeployment: !Equals [!Ref NumberOfAZs, "3"]
 
 Resources:
   ClusterRole:
@@ -327,6 +319,16 @@ Resources:
               - Effect: Allow
                 Action: 'autoscaling:*'
                 Resource: '*'
+        - PolicyName: FetchClusterScript
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                  - arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*
+                  - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+
   ClusterInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -308,7 +308,12 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: 'sqs:*'
+                Action: 
+                  - sqs:GetQueueAttributes
+                  - sqs:SendMessageBatch
+                  - sqs:SendMessage
+                  - sqs:SendMessageBatch
+                  - sqs:GetQueueUrl
                 Resource: !GetAtt 
                   - MigrationSQS
                   - Arn

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -207,7 +207,30 @@ Parameters:
     Type: String
     Default: |
       IyBnZW5lcmF0ZWQgMjAyMS0wMy0xMCAwNDowNDoyOAoKZmVhdHVyZS1rZXktdmVyc2lvbiAgICAgICAgICAgICAgICAgIDIKc2VyaWFsLW51bWJlciAgICAgICAgICAgICAgICAgICAgICAgIDU2ODk1MzA1OAoKYWNjb3VudC1uYW1lICAgICAgICAgICAgICAgICAgICAgRXZhbHVhdGlvbl9MaWNlbnNlCgphY2NvdW50LUlEICAgICAgICAgICAgICAgICAgICAgICBBZXJvc3Bpa2VfXzQzNTcxMTM3NAoKYXNkYi1jaGFuZ2Utbm90aWZpY2F0aW9uICAgICAgICAgdHJ1ZQphc2RiLWNsdXN0ZXItbm9kZXMtbGltaXQgICAgICAgICAxCmFzZGItY29tcHJlc3Npb24gICAgICAgICAgICAgICAgIHRydWUKYXNkYi1lbmNyeXB0aW9uLWF0LXJlc3QgICAgICAgICAgdHJ1ZQphc2RiLWxkYXAgICAgICAgICAgICAgICAgICAgICAgICB0cnVlCmFzZGItcG1lbSAgICAgICAgICAgICAgICAgICAgICAgIHRydWUKYXNkYi1zdHJvbmctY29uc2lzdGVuY3kgICAgICAgICAgdHJ1ZQptZXNnLWptcy1jb25uZWN0b3IgICAgICAgICAgICAgICB0cnVlCm1lc2cta2Fma2EtY29ubmVjdG9yICAgICAgICAgICAgIHRydWUKcHJlc3RvLWNvbm5lY3RvciAgICAgICAgICAgICAgICAgdHJ1ZQpyYWYtcmVhbHRpbWUtYW5hbHlzaXMtZnJhbWV3b3JrICB0cnVlCgotLS0tLSBTSUdOQVRVUkUgLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCk1FVUNJRXhGN3VSYzBZdURvb3J6ZkNUR2NhdGgrQVB6U0doUi94M21pN0RuRFB6a0FpRUF1cjkzRVcwb2tlNVoKUWZ5c1l4dzZCb0tKRUI1STVlV2xXdDU2UzlxeGNySWsKLS0tLS0gRU5EIE9GIFNJR05BVFVSRSAtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQo=
-
+  QSS3BucketName:
+    AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
+      (-).
+    Default: aws-quickstart
+    Description: S3 bucket name for the Quick Start assets. The Quick Start bucket name
+      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: "^[0-9a-zA-Z-/]*$"
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), and a forward slash (/).
+    Default: quickstart-aerospike/
+    Description: S3 key prefix for the Quick Start assets. The prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      a forward slash (/).
+    Type: String
+  NumberOfAZs:
+    Type: String
+    AllowedValues: ["2", "3"]
+    Default: "3"
+    Description: Number of Availability Zones to use in the VPC. This must match the value entered for the AvailabilityZones parameter.
 Mappings:
   AWSAMIRegionMap:
     AMI:
@@ -251,6 +274,10 @@ Conditions:
   NotUsingEBS: !Equals 
     - !Ref EBS
     - 0
+
+Conditions:
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  3AZDeployment: !Equals [!Ref NumberOfAZs, "3"]
 
 Resources:
   ClusterRole:
@@ -362,11 +389,11 @@ Resources:
               content: !Sub
                 - |
                   #!/bin/bash
-                  aws s3 cp s3://${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh .
+                  aws s3 cp https://s3.amazonaws.com/aerospike.cloud-templates.test/QSTemp/11jun/aerospike_cluster.sh .
                   chmod +x aerospike_cluster.sh
                   ./aerospike_cluster.sh ${REGION} ${NamespaceFile} ${EnableCloudWatch}
-                - REGION: !Sub "${AWS::Region}"
-                - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+                - REGION: !Sub "${AWS::Region}" 
+                  S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               mode: '000744'
               owner: root
               group: root

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -317,7 +317,30 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: 'autoscaling:*'
+                Action:
+                  - autoscaling:CompleteLifecycleAction
+                  - autoscaling:DeleteLifecycleHook
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:DescribeLifecycleHooks
+                  - autoscaling:PutLifecycleHook
+                  - autoscaling:RecordLifecycleActionHeartbeat
+                  - autoscaling:CreateAutoScalingGroup
+                  - autoscaling:UpdateAutoScalingGroup
+                  - autoscaling:EnableMetricsCollection
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:DescribePolicies
+                  - autoscaling:DescribeScheduledActions
+                  - autoscaling:DescribeNotificationConfigurations
+                  - autoscaling:DescribeLifecycleHooks
+                  - autoscaling:SuspendProcesses
+                  - autoscaling:ResumeProcesses
+                  - autoscaling:AttachLoadBalancers
+                  - autoscaling:PutScalingPolicy
+                  - autoscaling:PutScheduledUpdateGroupAction
+                  - autoscaling:PutNotificationConfiguration
+                  - autoscaling:PutLifecycleHook
+                  - autoscaling:DescribeScalingActivities
+                  - autoscaling:DeleteAutoScalingGroup
                 Resource: '*'
         - PolicyName: FetchClusterScript
           PolicyDocument: 
@@ -326,7 +349,7 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub
-                  - arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*
+                  - arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}scripts/aerospike_cluster.sh
                   - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
 
   ClusterInstanceProfile:


### PR DESCRIPTION

Update (config file is formed correctly as per updates in script):
 ``` bash
 [ec2-user@ip-10-0-1-25 ~]$ cat /etc/aerospike/aerospike.conf

# Aerospike database configuration file for deployments using mesh heartbeats with systemd.

service {
	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
	proto-fd-max 15000
}

logging {
	console {
		context any info
	}
}

network {
	service {
		address any
		port 3000
		access-address 10.0.1.25 virtual

	}

	heartbeat {
		mode mesh
		port 3002 # Heartbeat port for this node.

		# List one or more other nodes, one ip-address & port per line:

		mesh-seed-address-port 10.0.1.25 3002

		mesh-seed-address-port 10.0.61.23 3002

		interval 250
		timeout 10
	}

	fabric {
		port 3001
	}

	info {
		port 3003
	}
}

namespace test {
	replication-factor 2
	memory-size 4G

	storage-engine memory
}

namespace bar {
	replication-factor 2
	memory-size 4G

	storage-engine memory

	# To use file storage backing, comment out the line above and use the
	# following lines instead.
#	storage-engine device {
#		file /opt/aerospike/data/bar.dat
#		filesize 16G
#		data-in-memory true # Store data in memory in addition to file.
#	}
}
```