### PR TITLE
Moving Bastion Stack to workload template

### DIFF
--- a/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
+++ b/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
@@ -46,12 +46,6 @@ Metadata:
       - NamespaceFile
       - FeatureKeyFile
     - Label:
-        default: Linux bastion configuration
-      Parameters:
-        - BastionAMIOS
-        - BastionInstanceType
-        - NumBastionHosts
-    - Label:
         default: AWS Quick Start configuration
       Parameters:
         - QSS3BucketName
@@ -76,12 +70,6 @@ Metadata:
         default: "Namespace file"
       EBS:
         default: "EBS volume size"
-      BastionAMIOS:
-        default: Bastion AMI operating system
-      BastionInstanceType:
-        default: Bastion instance type
-      NumBastionHosts:
-        default: Number of bastion hosts
       KeyPairName:
         default: EC2 key pair
       PrivateSubnet1CIDR:
@@ -115,42 +103,6 @@ Parameters:
     AllowedValues: ["2", "3"]
     Default: "3"
     Description: Number of Availability Zones to use in the VPC. This number must match the number of Availability Zones you chose for the AvailabilityZones parameter.
-  BastionInstanceType:
-    Default: t3.micro
-    Type: String
-    Description:  Type of EC2 instance for the bastion hosts.
-    AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-  NumBastionHosts:
-    AllowedValues:
-      - '1'
-      - '2'
-      - '3'
-      - '4'
-    Default: '1'
-    Description: Number of bastion hosts to create.
-    Type: String
-  BastionAMIOS:
-    AllowedValues:
-      - Amazon-Linux2-HVM
-    Default: Amazon-Linux2-HVM
-    Description: Linux distribution for the AMI to be used for the bastion instances.
-    Type: String
   KeyPairName:
     Description: Name of the key pair to be used to connect to your EC2 instances by using SSH.
     Type: AWS::EC2::KeyPair::KeyName
@@ -373,41 +325,6 @@ Resources:
         PublicSubnet3CIDR: !Ref 'PublicSubnet3CIDR'
         VPCCIDR: !Ref 'VPCCIDR'
 
-  BastionStack:
-    Metadata: { cfn-lint: { config: { ignore_checks: [ W9901 ] } } }
-    Type: 'AWS::CloudFormation::Stack'
-    Properties:
-      TemplateURL: !Sub 
-        - >-
-          https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template
-        - S3Region: !If 
-            - UsingDefaultBucket
-            - !Ref 'AWS::Region'
-            - !Ref QSS3BucketRegion
-          S3Bucket: !If 
-            - UsingDefaultBucket
-            - !Sub '${QSS3BucketName}-${AWS::Region}'
-            - !Ref QSS3BucketName
-      Parameters:
-        BastionInstanceType: !Ref BastionInstanceType
-        NumBastionHosts: !Ref NumBastionHosts
-        BastionAMIOS: !Ref BastionAMIOS
-        EnableTCPForwarding: 'true'
-        KeyPairName: !Ref KeyPairName
-        PublicSubnet1ID: !GetAtt
-          - VPCStack
-          - Outputs.PublicSubnet1ID
-        PublicSubnet2ID: !GetAtt
-          - VPCStack
-          - Outputs.PublicSubnet2ID
-        QSS3BucketName: !Ref QSS3BucketName
-        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-linux-bastion/'
-        QSS3BucketRegion: !Ref QSS3BucketRegion
-        RemoteAccessCIDR: !Ref AccessCIDR
-        VPCID: !GetAtt 
-          - VPCStack
-          - Outputs.VPCID
-
   AerospikeServerStack:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -423,9 +340,6 @@ Resources:
             - !Ref 'AWS::Region'
             - !Ref QSS3BucketRegion
       Parameters:
-        BastionSecurityGroupID: !GetAtt
-          - BastionStack
-          - Outputs.BastionSecurityGroupID
         VPCCIDR: !Ref VPCCIDR
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         KeyPairName: !Ref KeyPairName
@@ -442,11 +356,9 @@ Resources:
         NamespaceFile: !Ref NamespaceFile
         FeatureKeyFile: !If [ TrialLicense, "IyBnZW5lcmF0ZWQgMjAyMS0wMy0xMCAwNDowNDoyOAoKZmVhdHVyZS1rZXktdmVyc2lvbiAgICAgICAgICAgICAgICAgIDIKc2VyaWFsLW51bWJlciAgICAgICAgICAgICAgICAgICAgICAgIDU2ODk1MzA1OAoKYWNjb3VudC1uYW1lICAgICAgICAgICAgICAgICAgICAgRXZhbHVhdGlvbl9MaWNlbnNlCgphY2NvdW50LUlEICAgICAgICAgICAgICAgICAgICAgICBBZXJvc3Bpa2VfXzQzNTcxMTM3NAoKYXNkYi1jaGFuZ2Utbm90aWZpY2F0aW9uICAgICAgICAgdHJ1ZQphc2RiLWNsdXN0ZXItbm9kZXMtbGltaXQgICAgICAgICAxCmFzZGItY29tcHJlc3Npb24gICAgICAgICAgICAgICAgIHRydWUKYXNkYi1lbmNyeXB0aW9uLWF0LXJlc3QgICAgICAgICAgdHJ1ZQphc2RiLWxkYXAgICAgICAgICAgICAgICAgICAgICAgICB0cnVlCmFzZGItcG1lbSAgICAgICAgICAgICAgICAgICAgICAgIHRydWUKYXNkYi1zdHJvbmctY29uc2lzdGVuY3kgICAgICAgICAgdHJ1ZQptZXNnLWptcy1jb25uZWN0b3IgICAgICAgICAgICAgICB0cnVlCm1lc2cta2Fma2EtY29ubmVjdG9yICAgICAgICAgICAgIHRydWUKcHJlc3RvLWNvbm5lY3RvciAgICAgICAgICAgICAgICAgdHJ1ZQpyYWYtcmVhbHRpbWUtYW5hbHlzaXMtZnJhbWV3b3JrICB0cnVlCgotLS0tLSBTSUdOQVRVUkUgLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCk1FVUNJRXhGN3VSYzBZdURvb3J6ZkNUR2NhdGgrQVB6U0doUi94M21pN0RuRFB6a0FpRUF1cjkzRVcwb2tlNVoKUWZ5c1l4dzZCb0tKRUI1STVlV2xXdDU2UzlxeGNySWsKLS0tLS0gRU5EIE9GIFNJR05BVFVSRSAtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQo=", !Ref FeatureKeyFile ]
         QSS3BucketName: !Ref QSS3BucketName
+        AccessCIDR: !Ref AccessCIDR
 
 Outputs:
-  BastionHostIP:
-    Description: IP for bastion host.
-    Value: !GetAtt "BastionStack.Outputs.EIP1"
   Postdeployment:
     Description: To test your deployment, see the procedure in the deployment guide.
     Value: https://fwd.aws/Pa8Yw?

--- a/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
+++ b/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
@@ -343,11 +343,6 @@ Resources:
         VPCCIDR: !Ref VPCCIDR
         VPCID: !GetAtt VPCStack.Outputs.VPCID
         KeyPairName: !Ref KeyPairName
-        VPCSubnet: !Join
-          - ','
-          - - !GetAtt VPCStack.Outputs.PrivateSubnet1AID
-            - !GetAtt VPCStack.Outputs.PrivateSubnet2AID
-            - !If [ 3AZDeployment, !GetAtt VPCStack.Outputs.PrivateSubnet3AID, !Ref "AWS::NoValue" ]
         InstanceType: !Ref InstanceType
         Tenancy: !Ref Tenancy
         NumberOfInstances: !Ref NumberOfInstances
@@ -357,6 +352,12 @@ Resources:
         FeatureKeyFile: !If [ TrialLicense, "IyBnZW5lcmF0ZWQgMjAyMS0wMy0xMCAwNDowNDoyOAoKZmVhdHVyZS1rZXktdmVyc2lvbiAgICAgICAgICAgICAgICAgIDIKc2VyaWFsLW51bWJlciAgICAgICAgICAgICAgICAgICAgICAgIDU2ODk1MzA1OAoKYWNjb3VudC1uYW1lICAgICAgICAgICAgICAgICAgICAgRXZhbHVhdGlvbl9MaWNlbnNlCgphY2NvdW50LUlEICAgICAgICAgICAgICAgICAgICAgICBBZXJvc3Bpa2VfXzQzNTcxMTM3NAoKYXNkYi1jaGFuZ2Utbm90aWZpY2F0aW9uICAgICAgICAgdHJ1ZQphc2RiLWNsdXN0ZXItbm9kZXMtbGltaXQgICAgICAgICAxCmFzZGItY29tcHJlc3Npb24gICAgICAgICAgICAgICAgIHRydWUKYXNkYi1lbmNyeXB0aW9uLWF0LXJlc3QgICAgICAgICAgdHJ1ZQphc2RiLWxkYXAgICAgICAgICAgICAgICAgICAgICAgICB0cnVlCmFzZGItcG1lbSAgICAgICAgICAgICAgICAgICAgICAgIHRydWUKYXNkYi1zdHJvbmctY29uc2lzdGVuY3kgICAgICAgICAgdHJ1ZQptZXNnLWptcy1jb25uZWN0b3IgICAgICAgICAgICAgICB0cnVlCm1lc2cta2Fma2EtY29ubmVjdG9yICAgICAgICAgICAgIHRydWUKcHJlc3RvLWNvbm5lY3RvciAgICAgICAgICAgICAgICAgdHJ1ZQpyYWYtcmVhbHRpbWUtYW5hbHlzaXMtZnJhbWV3b3JrICB0cnVlCgotLS0tLSBTSUdOQVRVUkUgLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCk1FVUNJRXhGN3VSYzBZdURvb3J6ZkNUR2NhdGgrQVB6U0doUi94M21pN0RuRFB6a0FpRUF1cjkzRVcwb2tlNVoKUWZ5c1l4dzZCb0tKRUI1STVlV2xXdDU2UzlxeGNySWsKLS0tLS0gRU5EIE9GIFNJR05BVFVSRSAtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQo=", !Ref FeatureKeyFile ]
         QSS3BucketName: !Ref QSS3BucketName
         AccessCIDR: !Ref AccessCIDR
+        PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
+        PublicSubnet2ID: !GetAtt VPCStack.Outputs.PublicSubnet2ID
+        PublicSubnet3ID: !If [ 3AZDeployment, !GetAtt VPCStack.Outputs.PublicSubnet3ID, !Ref "AWS::NoValue" ]
+        PrivateSubnet1ID: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
+        PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
+        PrivateSubnet3ID: !If [ 3AZDeployment, !GetAtt VPCStack.Outputs.PrivateSubnet3AID, !Ref "AWS::NoValue" ]
 
 Outputs:
   Postdeployment:

--- a/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
+++ b/templates/aerospike-cluster-entrypoint-new-vpc.template.yaml
@@ -46,6 +46,12 @@ Metadata:
       - NamespaceFile
       - FeatureKeyFile
     - Label:
+        default: Linux bastion configuration
+      Parameters:
+      - BastionAMIOS
+      - BastionInstanceType
+      - NumBastionHosts
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
         - QSS3BucketName
@@ -70,6 +76,12 @@ Metadata:
         default: "Namespace file"
       EBS:
         default: "EBS volume size"
+      BastionAMIOS:
+        default: Bastion AMI operating system
+      BastionInstanceType:
+        default: Bastion instance type
+      NumBastionHosts:
+        default: Number of bastion hosts
       KeyPairName:
         default: EC2 key pair
       PrivateSubnet1CIDR:
@@ -103,6 +115,40 @@ Parameters:
     AllowedValues: ["2", "3"]
     Default: "3"
     Description: Number of Availability Zones to use in the VPC. This number must match the number of Availability Zones you chose for the AvailabilityZones parameter.
+  BastionInstanceType:
+    Default: t3.micro
+    Type: String
+    Description:  Type of EC2 instance for the bastion hosts.
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+  NumBastionHosts:
+    AllowedValues:
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: Number of bastion hosts to create.
+    Type: String
+  BastionAMIOS:
+    Default: Amazon-Linux2-HVM
+    Description: Linux distribution for the AMI to be used for the bastion instances.
+    Type: String
   KeyPairName:
     Description: Name of the key pair to be used to connect to your EC2 instances by using SSH.
     Type: AWS::EC2::KeyPair::KeyName
@@ -358,6 +404,9 @@ Resources:
         PrivateSubnet1ID: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
         PrivateSubnet2ID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         PrivateSubnet3ID: !If [ 3AZDeployment, !GetAtt VPCStack.Outputs.PrivateSubnet3AID, !Ref "AWS::NoValue" ]
+        BastionInstanceType: !Ref BastionInstanceType
+        NumBastionHosts: !Ref NumBastionHosts
+        BastionAMIOS: !Ref BastionAMIOS
 
 Outputs:
   Postdeployment:

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -58,8 +58,6 @@ Metadata:
           - QSS3KeyPrefix
           - QSS3BucketRegion
     ParameterLabels:
-      BastionSecurityGroupID:
-        default: Bastion security group ID
       KeyPairName:
         default: EC2 key pair
       VPCID:

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -126,8 +126,6 @@ Parameters:
     Description: Number of bastion hosts to create.
     Type: String
   BastionAMIOS:
-    AllowedValues:
-      - Amazon-Linux2-HVM
     Default: Amazon-Linux2-HVM
     Description: Linux distribution for the AMI to be used for the bastion instances.
     Type: String
@@ -801,6 +799,9 @@ Resources:
         - InstanceSecurityGroup
         - GroupId
 Outputs:
+  BastionHostIP:
+    Description: IP for bastion host.
+    Value: !GetAtt "BastionStack.Outputs.EIP1"
   AutoscalingID:
     Description: The Autoscaling Group ID that is used to deploy your cluster
     Value: !Ref ClusterGroup

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -33,9 +33,14 @@ Metadata:
           - KeyPairName
           - VPCID
           - VPCCIDR
-          - VPCSubnet
           - Tenancy
           - AccessCIDR
+          - PublicSubnet1ID
+          - PublicSubnet2ID
+          - PublicSubnet3ID
+          - PrivateSubnet1ID
+          - PrivateSubnet2ID
+          - PrivateSubnet3ID
       - Label:
           default: Aerospike configuration
         Parameters:
@@ -64,8 +69,6 @@ Metadata:
         default: VPC ID
       VPCCIDR:
         default: CIDR for the VPC
-      VPCSubnet:
-        default: VPC subnet
       Tenancy:
         default: Tenancy
       NumberOfInstances:
@@ -148,9 +151,30 @@ Parameters:
       of 0.0.0.0/0 allows access from any IP address."
     Type: String
     Default: 0.0.0.0/0
-  VPCSubnet:
-    Description: Subnet that links to the instance in the selected VPC. At least two Subnets are required.
-    Type: 'List<AWS::EC2::Subnet::Id>'
+  PublicSubnet1ID:
+    Type: String
+    Default: ""
+    Description: "ID of public subnet 1"
+  PublicSubnet2ID:
+    Type: String
+    Default: ""
+    Description: "ID of public subnet 2"
+  PublicSubnet3ID:
+    Type: String
+    Default: ""
+    Description: "(Optional) ID of public subnet 3"
+  PrivateSubnet1ID:
+    Type: String
+    Default: ""
+    Description: "ID of private subnet 1"
+  PrivateSubnet2ID:
+    Type: String
+    Default: ""
+    Description: "ID of private subnet 2"
+  PrivateSubnet3ID:
+    Type: String
+    Default: ""
+    Description: "(Optional) ID of private subnet 3"
   Tenancy:
     Description: Tenancy of the Aerospike instances. Choose "dedicated" to change the host from shared (default).
     Type: String
@@ -370,6 +394,10 @@ Conditions:
   NotUsingEBS: !Equals 
     - !Ref EBS
     - 0
+  3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  2AZDeployment: !Or
+    - !Not [!Equals [!Ref PrivateSubnet2ID, ""]]
+    - !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
 
 Resources:
   BastionStack:
@@ -393,8 +421,8 @@ Resources:
         BastionAMIOS: !Ref BastionAMIOS
         EnableTCPForwarding: 'true'
         KeyPairName: !Ref KeyPairName
-        PublicSubnet1ID: !Select [ 0, !Ref VPCSubnet ]
-        PublicSubnet2ID: !Select [ 1, !Ref VPCSubnet ]
+        PublicSubnet1ID: !Ref PublicSubnet1ID
+        PublicSubnet2ID: !If [2AZDeployment, !Ref PublicSubnet2ID, !Ref "AWS::NoValue"]
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-linux-bastion/'
         QSS3BucketRegion: !Ref QSS3BucketRegion
@@ -491,10 +519,10 @@ Resources:
       DesiredCapacity: !Ref NumberOfInstances
       MinSize: '1'
       MaxSize: '15'
-      VPCZoneIdentifier:
-        - !Join 
-          - ','
-          - !Ref VPCSubnet
+      VPCZoneIdentifier: !If
+        - 3AZDeployment
+        - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID, !Ref PrivateSubnet3ID ]
+        - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID ]
       Tags:
         - Key: StackID
           Value: !Ref 'AWS::StackId'

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -35,6 +35,7 @@ Metadata:
           - VPCCIDR
           - VPCSubnet
           - Tenancy
+          - AccessCIDR
       - Label:
           default: Aerospike configuration
         Parameters:
@@ -47,11 +48,15 @@ Metadata:
       - Label:
           default: Linux bastion configuration
         Parameters:
-          - BastionSecurityGroupID
+          - BastionAMIOS
+          - BastionInstanceType
+          - NumBastionHosts
       - Label:
           default: AWS Quick Start configuration
         Parameters:
           - QSS3BucketName
+          - QSS3KeyPrefix
+          - QSS3BucketRegion
     ParameterLabels:
       BastionSecurityGroupID:
         default: Bastion security group ID
@@ -73,16 +78,59 @@ Metadata:
         default: Instance type
       EBS:
         default: EBS volume size
+      BastionAMIOS:
+        default: Bastion AMI operating system
+      BastionInstanceType:
+        default: Bastion instance type
+      NumBastionHosts:
+        default: Number of bastion hosts
       NamespaceFile:
         default: Namespace file
       FeatureKeyFile:
         default: Feature key file
       QSS3BucketName:
         default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+      QSS3BucketRegion:
+        default: Quick Start S3 bucket Region
 Parameters:
-  BastionSecurityGroupID:
-    Description: ID of the bastion host security group (e.g., sg-7f16e910).
-    Type: 'AWS::EC2::SecurityGroup::Id'
+  BastionInstanceType:
+    Default: t3.micro
+    Type: String
+    Description:  Type of EC2 instance for the bastion hosts.
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+  NumBastionHosts:
+    AllowedValues:
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: Number of bastion hosts to create.
+    Type: String
+  BastionAMIOS:
+    AllowedValues:
+      - Amazon-Linux2-HVM
+    Default: Amazon-Linux2-HVM
+    Description: Linux distribution for the AMI to be used for the bastion instances.
+    Type: String
   KeyPairName:
     Description: Name of the key pair to be used to connect to your EC2 instances by using SSH.
     Type: 'AWS::EC2::KeyPair::KeyName'
@@ -96,8 +144,14 @@ Parameters:
     Default: 10.0.0.0/16
     ConstraintDescription: Must be in format x.x.0.0/16.
     AllowedPattern: '^([0-9]{1,3}\.){2}([0]{1}.)[0]{1}(\/[16]{2})$'
+  AccessCIDR:
+    AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$"
+    Description: "CIDR IP range permitted to access Aerospike. A value
+      of 0.0.0.0/0 allows access from any IP address."
+    Type: String
+    Default: 0.0.0.0/0
   VPCSubnet:
-    Description: Subnet that links to the instance in the selected VPC.
+    Description: Subnet that links to the instance in the selected VPC. At least two Subnets are required.
     Type: 'List<AWS::EC2::Subnet::Id>'
   Tenancy:
     Description: Tenancy of the Aerospike instances. Choose "dedicated" to change the host from shared (default).
@@ -250,6 +304,29 @@ Parameters:
       uppercase letters, and hyphens, but do not start or end with a hyphen (-). 
       See https://aws-quickstart.github.io/option1.html.
     Type: String
+  QSS3BucketRegion:
+    Default: 'us-east-1'
+    Description: 'AWS Region where the Quick Start S3 bucket (QSS3BucketName) is 
+    hosted. Keep the default Region unless you are customizing the template. 
+    Changing this Region updates code references to point to a new Quick Start location. 
+    When using your own bucket, specify the Region. 
+    See https://aws-quickstart.github.io/option1.html.'
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: "^[0-9a-zA-Z-/]*$"
+    ConstraintDescription: The Quick Start S3 key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), and forward slashes (/). The prefix should
+      end with a forward slash (/).
+    Default: quickstart-aerospike/
+    Description: S3 key prefix that is used to simulate a directory for your copy of the 
+      Quick Start assets. Keep the default prefix unless you are customizing 
+      the template. Changing this prefix updates code references to point to 
+      a new Quick Start location. This prefix can include numbers, lowercase 
+      letters, uppercase letters, hyphens (-), and forward slashes (/). End with 
+      a forward slash. See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html 
+      and https://aws-quickstart.github.io/option1.html.
+    Type: String
+
 Mappings:
   AWSAMIRegionMap:
     AMI:
@@ -297,6 +374,35 @@ Conditions:
     - 0
 
 Resources:
+  BastionStack:
+    Metadata: { cfn-lint: { config: { ignore_checks: [ W9901 ] } } }
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Sub 
+        - >-
+          https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template
+        - S3Region: !If 
+            - UsingDefaultBucket
+            - !Ref 'AWS::Region'
+            - !Ref QSS3BucketRegion
+          S3Bucket: !If 
+            - UsingDefaultBucket
+            - !Sub '${QSS3BucketName}-${AWS::Region}'
+            - !Ref QSS3BucketName
+      Parameters:
+        BastionInstanceType: !Ref BastionInstanceType
+        NumBastionHosts: !Ref NumBastionHosts
+        BastionAMIOS: !Ref BastionAMIOS
+        EnableTCPForwarding: 'true'
+        KeyPairName: !Ref KeyPairName
+        PublicSubnet1ID: !Select [ 0, !Ref VPCSubnet ]
+        PublicSubnet2ID: !Select [ 1, !Ref VPCSubnet ]
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Sub '${QSS3KeyPrefix}submodules/quickstart-linux-bastion/'
+        QSS3BucketRegion: !Ref QSS3BucketRegion
+        RemoteAccessCIDR: !Ref AccessCIDR
+        VPCID: !Ref VPCID
+
   PsuedoRandom:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -651,7 +757,9 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          SourceSecurityGroupId: !Ref BastionSecurityGroupID
+          SourceSecurityGroupId: !GetAtt
+          - BastionStack
+          - Outputs.BastionSecurityGroupID
         - IpProtocol: icmp
           FromPort: -1
           ToPort: -1

--- a/templates/aerospike-cluster-workload.template.yaml
+++ b/templates/aerospike-cluster-workload.template.yaml
@@ -37,7 +37,6 @@ Metadata:
           - AccessCIDR
           - PublicSubnet1ID
           - PublicSubnet2ID
-          - PublicSubnet3ID
           - PrivateSubnet1ID
           - PrivateSubnet2ID
           - PrivateSubnet3ID
@@ -159,10 +158,6 @@ Parameters:
     Type: String
     Default: ""
     Description: "ID of public subnet 2"
-  PublicSubnet3ID:
-    Type: String
-    Default: ""
-    Description: "(Optional) ID of public subnet 3"
   PrivateSubnet1ID:
     Type: String
     Default: ""


### PR DESCRIPTION
*Issue #, if available:* : https://github.com/aws-quickstart/quickstart-aerospike/issues/33

*Description of changes:* : adding bastion stack in workload template


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Images : 

**SSH to bastion host and aerospike verification**
<img width="1303" alt="Screen Shot 2021-09-01 at 4 45 30 PM" src="https://user-images.githubusercontent.com/7384893/131760642-9b051148-722e-4a71-8379-4c048d02e281.png">

**Bastion instance is present in public subnet**
<img width="1201" alt="Screen Shot 2021-09-01 at 4 45 57 PM" src="https://user-images.githubusercontent.com/7384893/131760674-2b2c5402-9fde-499d-8469-8c18155a1eff.png">

**Aerospike instance is present in private subnet**
<img width="1196" alt="Screen Shot 2021-09-01 at 4 46 06 PM" src="https://user-images.githubusercontent.com/7384893/131760683-e0055bbc-c161-40be-a5f6-0bab49ef2805.png">

